### PR TITLE
Remove confusing Palindrome example

### DIFF
--- a/array.c
+++ b/array.c
@@ -5405,10 +5405,10 @@ rb_ary_drop_while(VALUE ary)
  *  Another sometimes useful iterator is #reverse_each which will iterate over
  *  the elements in the array in reverse order.
  *
- *     words = %w[rats live on no evil star]
- *     str = ""
- *     words.reverse_each { |word| str += "#{word.reverse} " }
- *     str #=> "rats live on no evil star "
+ *   words = %w[first second third fourth fifth sixth]
+ *   str = ""
+ *   words.reverse_each { |word| str += "#{word} " }
+ *   p str #=> "sixth fifth fourth third second first "
  *
  *  The #map method can be used to create a new array based on the original
  *  array, but with the values modified by the supplied block:


### PR DESCRIPTION
This example used palindromes to describe the reverse_each method, which seemed confusing and less helpful than an example that showed how the array reversed the order of the elements.
