### PR TITLE
* class.C: [DOC] Instance methods documentation fix

### DIFF
--- a/class.c
+++ b/class.c
@@ -1209,8 +1209,8 @@ rb_class_instance_methods(int argc, VALUE *argv, VALUE mod)
  *     mod.protected_instance_methods(include_super=true)   -> array
  *
  *  Returns a list of the protected instance methods defined in
- *  <i>mod</i>. If the optional parameter is not <code>false</code>, the
- *  methods of any ancestors are included.
+ *  <i>mod</i>. If the optional parameter is <code>false</code>, the
+ *  methods of any ancestors are not included.
  */
 
 VALUE
@@ -1224,8 +1224,8 @@ rb_class_protected_instance_methods(int argc, VALUE *argv, VALUE mod)
  *     mod.private_instance_methods(include_super=true)    -> array
  *
  *  Returns a list of the private instance methods defined in
- *  <i>mod</i>. If the optional parameter is not <code>false</code>, the
- *  methods of any ancestors are included.
+ *  <i>mod</i>. If the optional parameter is <code>false</code>, the
+ *  methods of any ancestors are not included.
  *
  *     module Mod
  *       def method1()  end
@@ -1247,8 +1247,8 @@ rb_class_private_instance_methods(int argc, VALUE *argv, VALUE mod)
  *     mod.public_instance_methods(include_super=true)   -> array
  *
  *  Returns a list of the public instance methods defined in <i>mod</i>.
- *  If the optional parameter is not <code>false</code>, the methods of
- *  any ancestors are included.
+ *  If the optional parameter is <code>false</code>, the methods of
+ *  any ancestors are not included.
  */
 
 VALUE
@@ -1264,8 +1264,8 @@ rb_class_public_instance_methods(int argc, VALUE *argv, VALUE mod)
  *  Returns a list of the names of public and protected methods of
  *  <i>obj</i>. This will include all the methods accessible in
  *  <i>obj</i>'s ancestors.
- *  If the <i>regular</i> parameter is set to <code>false</code>,
- *  Returns an array of obj's public and protected singleton methods,
+ *  If the optional parameter is <code>false</code>, it
+ *  returns an array of <i>obj<i>'s public and protected singleton methods,
  *  the array will not include methods in modules included in <i>obj</i>.
  *
  *     class Klass
@@ -1276,7 +1276,7 @@ rb_class_public_instance_methods(int argc, VALUE *argv, VALUE mod)
  *     k.methods[0..9]    #=> [:klass_method, :nil?, :===,
  *                        #    :==~, :!, :eql?
  *                        #    :hash, :<=>, :class, :singleton_class]
- *     k.methods.length   #=> 57
+ *     k.methods.length   #=> 56
  *
  *     k.methods(false)   #=> []
  *     def k.singleton_method; end

--- a/class.c
+++ b/class.c
@@ -1177,25 +1177,25 @@ class_instance_method_list(int argc, VALUE *argv, VALUE mod, int obj, int (*func
  *
  *  Returns an array containing the names of the public and protected instance
  *  methods in the receiver. For a module, these are the public and protected methods;
- *  for a class, they are the instance (not singleton) methods. With no
- *  argument, or with an argument that is <code>false</code>, the
- *  instance methods in <i>mod</i> are returned, otherwise the methods
- *  in <i>mod</i> and <i>mod</i>'s superclasses are returned.
+ *  for a class, they are the instance (not singleton) methods. If the optional
+ *  parameter is <code>false</code>, the methods of any ancestors are not included.
  *
  *     module A
  *       def method1()  end
  *     end
  *     class B
+ *       include A
  *       def method2()  end
  *     end
  *     class C < B
  *       def method3()  end
  *     end
  *
- *     A.instance_methods                #=> [:method1]
- *     B.instance_methods(false)         #=> [:method2]
- *     C.instance_methods(false)         #=> [:method3]
- *     C.instance_methods(true).length   #=> 43
+ *     A.instance_methods(false)                   #=> [:method1]
+ *     B.instance_methods(false)                   #=> [:method2]
+ *     B.instance_methods(true).include?(:method1) #=> true
+ *     C.instance_methods(false)                   #=> [:method3]
+ *     C.instance_methods.include?(:method2)       #=> true
  */
 
 VALUE


### PR DESCRIPTION
There are two doc changes here.
- 559abaf fixes the docs. They used to say, "with no arguments `instance_methods` the methods of ancestors are not included".  This is not true (with no argument then the ancestors methods are included).  I've also updated the examples 
-  39d7023 helps with readability, added `<i>` tags and updated the size of an array in an example
