### PR TITLE
fixed a minor missing comma issue in lib/irb.rb

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -138,7 +138,7 @@ STDOUT.sync = true
 # This example can be used in your +.irbrc+
 #
 #     IRB.conf[:PROMPT][:MY_PROMPT] = { # name of prompt mode
-#       :AUTO_INDENT => true            # enables auto-indent mode
+#       :AUTO_INDENT => true,           # enables auto-indent mode
 #       :PROMPT_I => nil,		# normal prompt
 #       :PROMPT_S => nil,		# prompt for continuated strings
 #       :PROMPT_C => nil,		# prompt for continuated statement


### PR DESCRIPTION
This is my first time contributing to `documenting-ruby` I'm not sure what the policy on such minor errors/omissions is, but here it is anyways.
