### PR TITLE
Fix indentation issue for Fiber#transfer example.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1587,7 +1587,7 @@ rb_fiber_m_resume(int argc, VALUE *argv, VALUE fib)
  *    fiber2.resume
  *    fiber3.resume
  *
- *    <em>produces</em>
+ *  <em>produces</em>
  *
  *    In fiber 2
  *    In fiber 1


### PR DESCRIPTION
I stumbled upon a minor issue on the `Fiber#transfer` example where it does not properly separate the code and the output of the example code. This pull request provides a fix.
