### PR TITLE
changed documentation for enumerable methods find and detect

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -204,7 +204,7 @@ find_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, memop))
  *  If no block is given, an enumerator is returned instead.
  *
  *     (1..10).detect  { |i| i % 5 == 0 and i % 7 == 0 }   #=> nil
- *     (1..100).detect { |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
+ *     (1..100).find { |i| i % 5 == 0 and i % 7 == 0 }   #=> 35
  *
  */
 


### PR DESCRIPTION
The docs right now under the enumerable method "find" contains only 2 examples using detect, and no examples with find.  The usual pattern throughout the rest of the docs is that when two methods are aliases, such as detect and find, then both methods will show an example using each alias.  So I just replaced one of the detect examples with find.  This will be more clear for those people going to look up enumerable's find method and are confused that it only has examples of detect.  
