### PR TITLE
improve IRB documentation

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -139,7 +139,7 @@ STDOUT.sync = true
 #
 #     IRB.conf[:PROMPT][:MY_PROMPT] = { # name of prompt mode
 #       :AUTO_INDENT => true,           # enables auto-indent mode
-#       :PROMPT_I => nil,		# normal prompt
+#       :PROMPT_I => ">> ",		# normal prompt
 #       :PROMPT_S => nil,		# prompt for continuated strings
 #       :PROMPT_C => nil,		# prompt for continuated statement
 #       :RETURN => "    ==>%s\n"	# format to return value


### PR DESCRIPTION
PROMPT_I in prompt customization example can't be nil
