### PR TITLE
Changed stdout documentation to detail the 's' paramater

### DIFF
--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -902,9 +902,9 @@ EOHELP
       @stdout
     end
 
-    # Sets the IO used as stdout. Defaults to STDOUT
-    def stdout=(s)
-      @stdout = s
+    # Sets the IO used as +stdout+. Defaults to STDOUT
+    def stdout=(stdout)
+      @stdout = stdout
     end
 
     # Returns the display expression list


### PR DESCRIPTION
Changed `stdout` documentation to reference the `s` parameter. `stdout` will no longer be flagged by rdoc as having an undocumented parameter.

This is my first Ruby documentation commit so let me know if I need to change anything :)
