### PR TITLE
Add doc for Array.reject, it maintains ordering

### DIFF
--- a/array.c
+++ b/array.c
@@ -3157,7 +3157,7 @@ rb_ary_reject_bang(VALUE ary)
  *     ary.reject                   -> Enumerator
  *
  *  Returns a new array containing the items in +self+ for which the given
- *  block is not +true+.
+ *  block is not +true+. The ordering of non-rejected elements is maintained.
  *
  *  See also Array#delete_if
  *


### PR DESCRIPTION
This addresses https://github.com/documenting-ruby/ruby/issues/41
