### PR TITLE
Hash documentation: JavaScript-like colon notation allowed for Symbol keys, even when other key in the same Hash aren't Symbols

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3849,7 +3849,7 @@ env_update(VALUE env, VALUE hash)
  *
  *    grades = { "Jane Doe" => 10, "Jim Doe" => 6 }
  *
- *  Hashes allow an alternate syntax form when your keys are always symbols.
+ *  Hashes allow an alternate syntax form for keys that are symbols:
  *  Instead of
  *
  *    options = { :font_size => 10, :font_family => "Arial" }


### PR DESCRIPTION
See #50
