### PR TITLE
Document that Timeout.timeout and Thread.raise are unsafe operations

### DIFF
--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -12,6 +12,10 @@
 # Timeout provides a way to auto-terminate a potentially long-running
 # operation if it hasn't finished in a fixed amount of time.
 #
+# It terminates the operation by raising an exception after the timeout has
+# expired. This is in general unsafe to use as it can generate
+# exceptions that the long-running code is not prepared to handle.
+#
 # Previous versions didn't use a module for namespacing, however
 # #timeout is provided for backwards compatibility.  You
 # should prefer Timeout#timeout instead.

--- a/thread.c
+++ b/thread.c
@@ -2161,6 +2161,11 @@ rb_thread_fd_close(int fd)
  *  Raises an exception from the given thread. The caller does not have to be
  *  +thr+. See Kernel#raise for more information.
  *
+ *  Raising an arbitrary exception in a thread is an unsafe operation. This
+ *  can raise an exception that the target thread is unprepared to handle, for
+ *  instance in a `rescue` block or in other code that would otherwise never
+ *  raise exceptions.
+ *
  *     Thread.abort_on_exception = true
  *     a = Thread.new { sleep(200) }
  *     a.raise("Gotcha")


### PR DESCRIPTION
<small>
I followed the directions [on the documenting ruby step by step guide](http://documenting-ruby.org/step-by-step-guide.html) -- happy to move this elsewhere if this is the wrong place for this patch.
</small>

As discussed in [this blog post](http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/), Timeout is a dangerous method that can result in really nasty & subtle bugs. Ruby's current documentation says only:

> Timeout provides a way to auto-terminate a potentially long-running operation if it hasn’t finished in a fixed amount of time.

which does not indicate that one should be very careful when attempting to use it.

Java documents extensively that using `Thread.stop` is discouraged, is both [in the javadocs for thread.stop](http://docs.oracle.com/javase/6/docs/api/java/lang/Thread.html#stop%28java.lang.Throwable%29) and on [this page explaining why the method was deprecated](http://docs.oracle.com/javase/6/docs/technotes/guides/concurrency/threadPrimitiveDeprecation.html)

Here's the beginning of the Java documentation for `Thread.stop`:

> **Deprecated.** This method is inherently unsafe. See stop() for details. An additional danger of this method is that it may be used to generate exceptions that the target thread is unprepared to handle (including checked exceptions that the thread could not possibly throw, were it not for this method). For more information, see Why are Thread.stop, Thread.suspend and Thread.resume Deprecated?.

I'd like to propose that Ruby include a similar warning. this is my first attempt at contributing to Ruby (documentation or otherwise), so very happy to make edits and explain more clearly.
