### PR TITLE
Specify default of Logger.new shift_age option

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -300,7 +300,7 @@ class Logger
   #   +STDOUT+, +STDERR+, or an open file).
   # +shift_age+::
   #   Number of old log files to keep, *or* frequency of rotation (+daily+,
-  #   +weekly+ or +monthly+).
+  #   +weekly+ or +monthly+). Defaults to +0+ (disabled).
   # +shift_size+::
   #   Maximum logfile size (only applies when +shift_age+ is a number).
   #

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -302,7 +302,8 @@ class Logger
   #   Number of old log files to keep, *or* frequency of rotation (+daily+,
   #   +weekly+ or +monthly+). Defaults to +0+ (disabled).
   # +shift_size+::
-  #   Maximum logfile size (only applies when +shift_age+ is a number).
+  #   Maximum logfile size in bytes (only applies when +shift_age+ is a number).
+  #   Defaults to +1048576+ (1MB).
   #
   # === Description
   #


### PR DESCRIPTION
Closes #64.  Please see issue for details.
