### PR TITLE
It's -> its

### DIFF
--- a/ext/bigdecimal/bigdecimal.c
+++ b/ext/bigdecimal/bigdecimal.c
@@ -931,7 +931,7 @@ BigDecimal_add(VALUE self, VALUE r)
   * If +b+ is a Float, the precision of the result is Float::DIG+1.
   *
   * If +b+ is a BigDecimal, the precision of the result is +b+'s precision of
-  * internal representation from platform. So, it's return value is platform
+  * internal representation from platform. So, its return value is platform
   * dependent.
   *
   */

--- a/ext/syslog/syslog.c
+++ b/ext/syslog/syslog.c
@@ -289,7 +289,7 @@ static VALUE mSyslog_set_mask(VALUE self, VALUE mask)
  * LOG_INFO::    Informational message
  * LOG_DEBUG::   Debugging information
  *
- * Each priority level also has a shortcut method that logs with it's named priority.
+ * Each priority level also has a shortcut method that logs with its named priority.
  * As an example, the two following statements would produce the same result:
  *
  *   Syslog.log(Syslog::LOG_ALERT, "Out of memory")

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -145,7 +145,7 @@ end
 #
 # This time RubyGems will accept your signed package and begin installing.
 #
-# While you're waiting for RubyGems to work it's magic, have a look at some of
+# While you're waiting for RubyGems to work its magic, have a look at some of
 # the other security commands by running <code>gem help cert</code>:
 #
 #   Options:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1357,7 +1357,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   ##
   # Activate this spec, registering it as a loaded spec and adding
-  # it's lib paths to $LOAD_PATH. Returns true if the spec was
+  # its lib paths to $LOAD_PATH. Returns true if the spec was
   # activated, false if it was previously activated. Freaks out if
   # there are conflicts upon activation.
 

--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -307,7 +307,7 @@ module URI
   # == Description
   # Returns a Regexp object which matches to URI-like strings.
   # The Regexp object returned by this method includes arbitrary
-  # number of capture group (parentheses).  Never rely on it's number.
+  # number of capture group (parentheses).  Never rely on its number.
   #
   # == Usage
   #

--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -18,7 +18,7 @@ require "delegate"
 #
 # With help from WeakRef, we can implement our own rudimentary WeakHash class.
 #
-# We will call it WeakHash, since it's really just a Hash except all of it's
+# We will call it WeakHash, since it's really just a Hash except all of its
 # keys and values can be garbage collected.
 #
 #     require 'weakref'

--- a/lib/xmlrpc/server.rb
+++ b/lib/xmlrpc/server.rb
@@ -71,7 +71,7 @@ class BasicServer
   #
   # Parameters +signature+ and +help+ are used by the Introspection method if
   # specified, where +signature+ is either an Array containing strings each
-  # representing a type of it's signature (the first is the return value) or
+  # representing a type of its signature (the first is the return value) or
   # an Array of Arrays if the method has multiple signatures.
   #
   # Value type-names are "int, boolean, double, string, dateTime.iso8601,


### PR DESCRIPTION
Found a few instances where "its" (possessive) should be used over "it's" (contraction for "it is").
