### PR TITLE
Fix a typo in the documentation for Time

### DIFF
--- a/time.c
+++ b/time.c
@@ -4922,7 +4922,7 @@ time_load(VALUE klass, VALUE str)
  *
  *    t.year #=> 1993
  *
- *  Was is daylight savings at the time?
+ *  Was it daylight savings at the time?
  *
  *    t.dst? #=> false
  *


### PR DESCRIPTION
Hi, found a small typo while on ruby-doc.org. Looking forward to making making more contributions to the docs