### PR TITLE
Edit documentation for IO#print function

### DIFF
--- a/io.c
+++ b/io.c
@@ -6971,15 +6971,16 @@ rb_f_printf(int argc, VALUE *argv)
  *     ios.print()             -> nil
  *     ios.print(obj, ...)     -> nil
  *
- *  Writes the given object(s) to <em>ios</em>. The stream must be
- *  opened for writing. If the output field separator (<code>$,</code>)
- *  is not <code>nil</code>, it will be inserted between each object.
- *  If the output record separator (<code>$\\</code>)
- *  is not <code>nil</code>, it will be appended to the output. If no
- *  arguments are given, prints <code>$_</code>. Objects that aren't
- *  strings will be converted by calling their <code>to_s</code> method.
- *  With no argument, prints the contents of the variable <code>$_</code>.
- *  Returns <code>nil</code>.
+ *  Writes the given object(s) to <em>ios</em>. The stream must be opened for writing.
+ *
+ *  Each given object that isn't a string will be converted to one by calling
+ *  its <code>to_s</code> method. It always returns <code>nil</code>.
+ *
+ *  When called without arguments it prints out the contents of <code>$_</code>.
+ *  If the <em>output field separator</em> (<code>$,</code>) is not <code>nil</code>,
+ *  and is a string, it is inserted between objects.
+ *  If the <em>output record separator</em> (<code>$\\</code>) is not <code>nil</code>,
+ *  and is a string, it is appended to the output.
  *
  *     $stdout.print("This is ", 100, " percent.\n")
  *


### PR DESCRIPTION
Important changes made:
- Delete duplicate sentence regarding global variable "$_"
- Split the whole paragraph into three semantically related smaller ones
- Emphasize names of separators
- Add "and is a string" where usage of "$'" and "$\" is explained