### PR TITLE
Adding showing examples for `String#length`

### DIFF
--- a/string.c
+++ b/string.c
@@ -1481,6 +1481,9 @@ rb_str_strlen(VALUE str)
  *     str.size     -> integer
  *
  *  Returns the character length of <i>str</i>.
+ *
+ *    "hello".length       #=> 5
+ *    "12 34".length       #=> 5
  */
 
 VALUE


### PR DESCRIPTION
Two examples added to demonstrate the effect of
the `#length` instance method over the `String` object.

Related and closes #98 