### PR TITLE
docs: fix typo in ENV.fetch comment

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2876,7 +2876,7 @@ rb_f_getenv(VALUE obj, VALUE name)
  *
  * Retrieves the environment variable +name+.
  *
- * If the given name does not exist and neither +default+ nor a block a
+ * If the given name does not exist and neither +default+ nor a block are
  * provided an IndexError is raised.  If a block is given it is called with
  * the missing name to provide a value.  If a default value is given it will
  * be returned when no block is given.


### PR DESCRIPTION
Hello! 👋🏼 

First-time contributor here. This PR attempts to fix a typo in the docs for `ENV.fetch`. I found this typo while reading https://ruby-doc.org/core-2.1.1/ENV.html

Screenshot:

![Screen Shot 2021-03-11 at 5 43 49 PM](https://user-images.githubusercontent.com/2289/110879257-7f260900-8291-11eb-90cc-72e0c5e81ad9.png)


Before:

```
neither +default+ nor a block a provided
```

After:

```
neither +default+ nor a block are provided
```


Confession: I have not thoroughly read the contributing docs at http://documenting-ruby.org/step-by-step-guide.html#SetUp yet. Please let me know if I'm in the wrong place or missing some part of the process. Thanks!