### PR TITLE
Correct 'while loop' code example description

### DIFF
--- a/doc/syntax/control_expressions.rdoc
+++ b/doc/syntax/control_expressions.rdoc
@@ -268,7 +268,7 @@ The +while+ loop executes while a condition is true:
 
   p a
 
-Prints the numbers 0 through 10.  The condition <code>a < 10</code> is checked
+Prints the numbers 0 through 9.  The condition <code>a < 10</code> is checked
 before the loop is entered, then the body executes, then the condition is
 checked again.  When the condition results in false the loop is terminated.
 


### PR DESCRIPTION
In the example for using a 'while loop' under the 'Control Expressions' section, the code example is:

```
a = 0

while a < 10 do
  p a
  a += 1
end

p a
```

The description below the code example is:

Prints the numbers 0 through 10. The condition a < 10 is checked before the loop is entered, then the body executes, then the condition is checked again. When the condition results in false the loop is terminated.

The description should be 'Prints the numbers 0 through 9' based on the code example.